### PR TITLE
Support binary only runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Synnefo
+[ ![Package Page](https://api.bintray.com/packages/derwasp/random/junit.synnefo/images/download.svg) ](https://bintray.com/derwasp/random/junit.synnefo/)
 
 Synnefo: run your Cucumber test in parallel via AWS CodeBuild and JUnit.
 

--- a/src/main/kotlin/albelli/junit/synnefo/api/Synnefo.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/api/Synnefo.kt
@@ -2,16 +2,13 @@ package albelli.junit.synnefo.api
 
 import albelli.junit.synnefo.runtime.*
 import albelli.junit.synnefo.runtime.exceptions.SynnefoException
-import cucumber.api.CucumberOptions
 import cucumber.runtime.junit.FeatureRunner
 import cucumber.runtime.model.CucumberFeature
 import org.junit.runner.Description
 import org.junit.runner.notification.RunNotifier
 import org.junit.runners.ParentRunner
-import org.junit.runners.model.InitializationError
 import sun.reflect.generics.reflectiveObjects.NotImplementedException
 import java.io.File
-import java.net.URISyntaxException
 import java.util.*
 
 @Suppress("unused")
@@ -59,7 +56,7 @@ constructor(clazz: Class<*>) : ParentRunner<FeatureRunner>(clazz) {
     }
 
     public override fun getChildren(): List<FeatureRunner> {
-        throw NotImplementedException()
+        return listOf()
     }
 
     override fun describeChild(child: FeatureRunner): Description {

--- a/src/main/kotlin/albelli/junit/synnefo/api/Synnefo.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/api/Synnefo.kt
@@ -14,24 +14,27 @@ import java.util.*
 @Suppress("unused")
 class Synnefo
 constructor(clazz: Class<*>) : ParentRunner<FeatureRunner>(clazz) {
+
     private val synnefoLoader: SynnefoLoader
     private val synnefoProperties: SynnefoProperties
     private val cucumberFeatures: List<CucumberFeature>
     private val runnerInfoList: MutableList<SynnefoRunnerInfo>
     private val callbacks: SynnefoCallbacks
+    private val classLoader: ClassLoader = clazz.classLoader!!
 
     init {
+
         val opt  = loadOptions(clazz)
 
         val classPath = File(clazz.protectionDomain.codeSource.location.toURI()).path
         callbacks = SynnefoCallbacks(clazz)
 
-        synnefoLoader = SynnefoLoader(opt, clazz.classLoader)
+        synnefoLoader = SynnefoLoader(opt, classLoader)
         cucumberFeatures = synnefoLoader.getCucumberFeatures()
 
         runnerInfoList = ArrayList()
 
-        synnefoProperties = SynnefoProperties(opt, classPath, cucumberFeatures.map { it.uri.schemeSpecificPart })
+        synnefoProperties = SynnefoProperties(opt, classPath, cucumberFeatures.map { it.uri })
 
         if (synnefoProperties.runLevel == SynnefoRunLevel.FEATURE) {
             for (feature in cucumberFeatures) {
@@ -45,7 +48,7 @@ constructor(clazz: Class<*>) : ParentRunner<FeatureRunner>(clazz) {
     }
 
     override fun run(notifier: RunNotifier) {
-        val synnefoRunner = SynnefoRunner(runnerInfoList, synnefoProperties, notifier)
+        val synnefoRunner = SynnefoRunner(runnerInfoList, synnefoProperties, notifier, classLoader)
 
         try {
             callbacks.beforeAll()

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
@@ -262,7 +262,7 @@ internal class AmazonCodeBuildScheduler(private val settings: SynnefoProperties,
 
         val startBuildResponse =  codeBuild.startBuild(buildStartRequest).await()
         val buildId = startBuildResponse.build().id()
-        val junitDescription = Description.createTestDescription(info.cucumberFeatureLocation, info.cucumberFeatureLocation)
+        val junitDescription = Description.createTestDescription("Synnefo", info.cucumberFeatureLocation)
         job.notifier.fireTestStarted(junitDescription)
 
         return ScheduledJob(job, buildId, info, junitDescription)

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/Extensions.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/Extensions.kt
@@ -1,5 +1,9 @@
 package albelli.junit.synnefo.runtime
 
+import java.io.File
+import java.net.URI
+import java.net.URL
+
 internal fun <E> MutableList<E>.dequeueUpTo(limit: Int): MutableList<E> {
     val from = Math.max(0, this.size - limit)
     val to = Math.min(this.size, from + limit)
@@ -18,4 +22,19 @@ internal fun StringBuilder.appendWithEscaping(s: String) {
 
 internal fun String.isNullOrWhiteSpace(): Boolean {
     return this.trim { it <= ' ' }.isEmpty()
+}
+
+internal fun URI.toValidURL(classLoader: ClassLoader): URL {
+    if ("classpath" == this.scheme) {
+        var path = this.path
+        if (path.startsWith("/")) {
+            path = path.substring("/".length)
+        }
+        return classLoader.getResource(path)
+    } else return if (this.scheme == null && this.path != null) {
+        //Assume that its a file.
+        File(this.path).toURI().toURL()
+    } else {
+        this.toURL()
+    }
 }

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/Extensions.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/Extensions.kt
@@ -25,7 +25,7 @@ internal fun String.isNullOrWhiteSpace(): Boolean {
 }
 
 internal fun URI.toValidURL(classLoader: ClassLoader): URL {
-    if ("classpath" == this.scheme) {
+    if ("classpath" == this.scheme.toLowerCase()) {
         var path = this.path
         if (path.startsWith("/")) {
             path = path.substring("/".length)

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/SynnefoProperties.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/SynnefoProperties.kt
@@ -4,6 +4,7 @@ import albelli.junit.synnefo.api.SynnefoOptions
 import albelli.junit.synnefo.api.SynnefoRunLevel
 import albelli.junit.synnefo.runtime.exceptions.SynnefoException
 import cucumber.api.CucumberOptions
+import java.net.URI
 
 internal class SynnefoProperties(
         val threads: Int ,
@@ -19,7 +20,7 @@ internal class SynnefoProperties(
         val bucketOutputFolder: String,
         val outputFileName: String,
         val classPath: String,
-        val featurePaths: List<String>)
+        val featurePaths: List<URI>)
 {
     constructor(opt: SynnefoOptions): this(
             getAnyVar("threads", opt.threads),
@@ -38,7 +39,7 @@ internal class SynnefoProperties(
             listOf()
             )
 
-    constructor(opt: SynnefoProperties, classPath: String, featurePaths: List<String>): this(
+    constructor(opt: SynnefoProperties, classPath: String, featurePaths: List<URI>): this(
             opt.threads,
             opt.runLevel,
             opt.reportTargetDir,

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/SynnefoRunner.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/SynnefoRunner.kt
@@ -8,9 +8,10 @@ import org.junit.runner.notification.RunNotifier
 internal class SynnefoRunner(
         private val runnerInfoList: List<SynnefoRunnerInfo>,
         private val synnefoProperties: SynnefoProperties,
-        private val notifier: RunNotifier) {
+        private val notifier: RunNotifier,
+        private val classLoader: ClassLoader) {
 
-    private val scheduler: AmazonCodeBuildScheduler = AmazonCodeBuildScheduler(synnefoProperties)
+    private val scheduler: AmazonCodeBuildScheduler = AmazonCodeBuildScheduler(synnefoProperties, classLoader)
 
     fun run() {
         val job = AmazonCodeBuildScheduler.Job(

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/SynnefoRunnerInfo.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/SynnefoRunnerInfo.kt
@@ -14,7 +14,9 @@ internal class SynnefoRunnerInfo(
 
     val cucumberFeatureLocation: String
         get() {
-            val featureLocation = this.cucumberFeature.uri.schemeSpecificPart
+            val featureLocation = this.cucumberFeature.uri
+                    .toString()
+                    .replace("classpath:/","classpath:") // hack for the cucumber loader
 
             return if (synnefoRunLevel == SynnefoRunLevel.SCENARIO && lineId != null) {
                 String.format("%s:%s", featureLocation, lineId)

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/SynnefoRunnerInfo.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/SynnefoRunnerInfo.kt
@@ -17,6 +17,7 @@ internal class SynnefoRunnerInfo(
             val featureLocation = this.cucumberFeature.uri
                     .toString()
                     .replace("classpath:/","classpath:") // hack for the cucumber loader
+                    .replace("file:", "")
 
             return if (synnefoRunLevel == SynnefoRunLevel.SCENARIO && lineId != null) {
                 String.format("%s:%s", featureLocation, lineId)


### PR DESCRIPTION
Support a possibility to use class path as the source for features, like this: `features = "classpath:features/"`
It means that we can skip uploading feature files and just use those embedded in the binary.
The code is hacky, again.
For whatever reason cucumber doesn't like when classpath path starts with a slash, e.g. `classpath:/feature/` and wants it to be `classpath:feature/`. Maybe that is a java thing, but I figured that I might as well just string replace that.

**Unrelated changes:**
 - return 0 children instead of an exception. Needed for the JUnit4 runner when started from commandline
 - Add some console logging, it's better than no logging at all
 - badge :D