### PR TITLE
Use aws/codebuild/standard:2.0 from codebuild

### DIFF
--- a/src/main/kotlin/albelli/junit/synnefo/api/SynnefoOptions.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/api/SynnefoOptions.kt
@@ -48,7 +48,7 @@ annotation class SynnefoOptions(
         /**
          * @return the name of the docker image to run the job on (/aws/codebuild or docker hub or ECR)
          */
-        val image: String = "albelli/aws-codebuild-docker-images:java-openjdk-8-chromedriver",
+        val image: String = "aws/codebuild/standard:2.0",
 
         /**
          * @return the type of the CodeBuild instance to use


### PR DESCRIPTION
https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html
It already has both chrome and firefox, java & .net and all of it

Will be waiting for this to be approved/declined:
https://github.com/aws/aws-codebuild-docker-images/pull/196