### PR TITLE
Add cucumber forced tags

### DIFF
--- a/src/main/kotlin/albelli/junit/synnefo/api/SynnefoOptions.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/api/SynnefoOptions.kt
@@ -21,6 +21,12 @@ annotation class SynnefoOptions(
          * @return target directory of Synnefo-report (this defaults to 'target' directory)
          */
         val reportTargetDir: String = "build/Synnefo",
+
+        /**
+         * @return special tags that would be added as "AND" to any other cucumber tags
+         */
+        val cucumberForcedTags: String = "",
+
         /**
          * @return the Cucumber options
          */

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/SynnefoProperties.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/SynnefoProperties.kt
@@ -19,6 +19,7 @@ internal class SynnefoProperties(
         val bucketSourceFolder: String,
         val bucketOutputFolder: String,
         val outputFileName: String,
+        val cucumberForcedTags: String,
         val classPath: String,
         val featurePaths: List<URI>)
 {
@@ -35,6 +36,7 @@ internal class SynnefoProperties(
             getAnyVar("bucketSourceFolder", opt.bucketSourceFolder),
             getAnyVar("bucketOutputFolder", opt.bucketOutputFolder),
             getAnyVar("outputFileName", opt.outputFileName),
+            opt.cucumberForcedTags,
             "",
             listOf()
             )
@@ -52,6 +54,7 @@ internal class SynnefoProperties(
             opt.bucketSourceFolder,
             opt.bucketOutputFolder,
             opt.outputFileName,
+            opt.cucumberForcedTags,
             classPath,
             featurePaths
     )

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/SynnefoRuntimeOptionsCreator.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/SynnefoRuntimeOptionsCreator.kt
@@ -1,10 +1,10 @@
 package albelli.junit.synnefo.runtime
 
 import cucumber.api.CucumberOptions
-import kotlin.collections.ArrayList
 
 internal class SynnefoRuntimeOptionsCreator(synnefoProperties: SynnefoProperties) {
     private val cucumberOptions: CucumberOptions = synnefoProperties.cucumberOptions
+    private val cucumberForcedTags: String = synnefoProperties.cucumberForcedTags
     private val runtimeOptions = ArrayList<String>()
 
     init {
@@ -18,8 +18,13 @@ internal class SynnefoRuntimeOptionsCreator(synnefoProperties: SynnefoProperties
     private fun createRuntimeOptions(cucumberOptions: CucumberOptions): List<String> {
         val runtimeOptions = ArrayList<String>()
 
+        val tags = envCucumberOptionOverride("tags", cucumberOptions.tags.toList()).map {
+            if(cucumberForcedTags.isNullOrWhiteSpace()) it
+            else "($it) AND ($cucumberForcedTags)"
+        }
+        runtimeOptions.addAll(optionParser("--tags", tags))
+
         runtimeOptions.addAll(optionParser("--glue", envCucumberOptionOverride("glue", cucumberOptions.glue.toList())))
-        runtimeOptions.addAll(optionParser("--tags", envCucumberOptionOverride("tags", cucumberOptions.tags.toList())))
         runtimeOptions.addAll(optionParser("--plugin", envCucumberOptionOverride("plugin", cucumberOptions.plugin.toList())))
         runtimeOptions.addAll(optionParser("--name", envCucumberOptionOverride("name", cucumberOptions.name.toList())))
         runtimeOptions.addAll(optionParser("--junit", envCucumberOptionOverride("junit", cucumberOptions.junit.toList())))

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/SynnefoRuntimeOptionsCreator.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/SynnefoRuntimeOptionsCreator.kt
@@ -20,7 +20,7 @@ internal class SynnefoRuntimeOptionsCreator(synnefoProperties: SynnefoProperties
 
         val tags = envCucumberOptionOverride("tags", cucumberOptions.tags.toList()).map {
             if(cucumberForcedTags.isNullOrWhiteSpace()) it
-            else "($it) AND ($cucumberForcedTags)"
+            else "($it) and ($cucumberForcedTags)"
         }
         runtimeOptions.addAll(optionParser("--tags", tags))
 


### PR DESCRIPTION
In order to be able to override cucumber tags and still have a possibility to have multiple scenarios, we need to "pin" certain tags so they won't be changed.

Consider the following scenario:
 - We have 2 suites: A, that requires `@potatoes` and B that doesn't require `@potatoes`
 - We set cucumber tags for both suites:
    - A: `@potatoes`
    - B: `not @potatoes`
 - We ran the tests with `-Dtags=@regression`
 - Both suites get executed and the initial tags are gone. So both suites will run with the same tag: `@regression`

What this PR does is creates a `forcedCucumberTags` annotation property that is set only in the code and can't be changed.
What it does is it "and-s" itself to each and every tag.
So if we would use it in this case, the resulting tags for the A tests would be: `@regression and @potatoes` and for the tests B: `@regression and (not @potatoes)`

Cucumber tags docu: https://cucumber.io/docs/cucumber/api/#tags