### PR TITLE
Add support for multiple annotations for each class.

### DIFF
--- a/src/main/kotlin/albelli/junit/synnefo/api/Synnefo.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/api/Synnefo.kt
@@ -69,15 +69,26 @@ constructor(clazz: Class<*>) : ParentRunner<FeatureRunner>(clazz) {
     }
 
     private fun loadOptions(clazz: Class<*>): List<SynnefoProperties> {
+        val allAnnotations = ArrayList<SynnefoOptions>()
+
         val synnefoOptions = clazz.declaredAnnotations
                 .filter {
                     it is SynnefoOptions
                 }
                 .map { it as SynnefoOptions }
 
-        if(synnefoOptions.count() == 0)
+        allAnnotations.addAll(synnefoOptions)
+
+        val synnefoOptions2 = clazz.declaredAnnotations
+                .filter {
+                    it is SynnefoOptionsGroup
+                }
+                .flatMap { (it as SynnefoOptionsGroup).value.toList() }
+        allAnnotations.addAll(synnefoOptions2)
+
+        if(allAnnotations.count() == 0)
             throw SynnefoException("Runner class is not annotated with at least one @SynnefoOptions")
 
-        return synnefoOptions.map { SynnefoProperties(it) }
+        return allAnnotations.map { SynnefoProperties(it) }
     }
 }

--- a/src/main/kotlin/albelli/junit/synnefo/api/Synnefo.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/api/Synnefo.kt
@@ -16,7 +16,7 @@ constructor(clazz: Class<*>) : ParentRunner<FeatureRunner>(clazz) {
     private val callbacks: SynnefoCallbacks
     private val classLoader: ClassLoader = clazz.classLoader!!
 
-    private val runnersPropertiesPairs: ArrayList<Pair<SynnefoProperties, List<SynnefoRunnerInfo>>> = ArrayList()
+    private val runnerInfoList: ArrayList<SynnefoRunnerInfo> = ArrayList()
 
     init {
 
@@ -28,7 +28,6 @@ constructor(clazz: Class<*>) : ParentRunner<FeatureRunner>(clazz) {
         {
             val synnefoLoader = SynnefoLoader(opt, classLoader)
             val cucumberFeatures = synnefoLoader.getCucumberFeatures()
-            val runnerInfoList : MutableList<SynnefoRunnerInfo> = ArrayList()
             val synnefoProperties = SynnefoProperties(opt , classPath, cucumberFeatures.map { f -> f.uri })
 
             if (synnefoProperties.runLevel == SynnefoRunLevel.FEATURE) {
@@ -40,9 +39,6 @@ constructor(clazz: Class<*>) : ParentRunner<FeatureRunner>(clazz) {
                     runnerInfoList.add(SynnefoRunnerInfo(synnefoProperties, scenario, line))
                 }
             }
-
-            val pair = Pair(synnefoProperties, runnerInfoList)
-            runnersPropertiesPairs.add(pair)
         }
     }
 
@@ -50,7 +46,7 @@ constructor(clazz: Class<*>) : ParentRunner<FeatureRunner>(clazz) {
         val synnefoRunner = SynnefoRunner(classLoader, notifier)
         try {
             callbacks.beforeAll()
-            synnefoRunner.run(runnersPropertiesPairs)
+            synnefoRunner.run(runnerInfoList)
         } finally {
             callbacks.afterAll()
         }

--- a/src/main/kotlin/albelli/junit/synnefo/api/SynnefoOptions.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/api/SynnefoOptions.kt
@@ -8,6 +8,7 @@ import java.lang.annotation.RetentionPolicy
 
 @Retention(RetentionPolicy.RUNTIME)
 @java.lang.annotation.Repeatable(SynnefoOptions::class)
+@Repeatable
 annotation class SynnefoOptions(
 
         /**

--- a/src/main/kotlin/albelli/junit/synnefo/api/SynnefoOptions.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/api/SynnefoOptions.kt
@@ -6,8 +6,9 @@ import cucumber.api.CucumberOptions
 import java.lang.annotation.Retention
 import java.lang.annotation.RetentionPolicy
 
+@java.lang.annotation.Repeatable(SynnefoOptionsGroup::class)
 @Retention(RetentionPolicy.RUNTIME)
-@java.lang.annotation.Repeatable(SynnefoOptions::class)
+@Target(AnnotationTarget.CLASS)
 @Repeatable
 annotation class SynnefoOptions(
 
@@ -71,3 +72,7 @@ annotation class SynnefoOptions(
          */
         val outputFileName: String = "runResults.zip"
 )
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(AnnotationTarget.CLASS)
+annotation class SynnefoOptionsGroup(vararg val value: SynnefoOptions)

--- a/src/main/kotlin/albelli/junit/synnefo/api/SynnefoOptions.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/api/SynnefoOptions.kt
@@ -7,6 +7,7 @@ import java.lang.annotation.Retention
 import java.lang.annotation.RetentionPolicy
 
 @Retention(RetentionPolicy.RUNTIME)
+@java.lang.annotation.Repeatable(SynnefoOptions::class)
 annotation class SynnefoOptions(
 
         /**

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
@@ -169,7 +169,7 @@ internal class AmazonCodeBuildScheduler(private val classLoader: ClassLoader) {
                                 .map { it.await() }
 
                 currentQueue.addAll(scheduledJobs)
-                println("started ${currentBatch.count()} jobs")
+                println("started ${currentBatch.count()} jobs; current running total: ${currentQueue.size}; backlog: ${backlog.size}")
                 delay(2500)
             }
 

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/SynnefoRunnerInfo.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/SynnefoRunnerInfo.kt
@@ -4,7 +4,7 @@ import albelli.junit.synnefo.api.SynnefoRunLevel
 import cucumber.runtime.model.CucumberFeature
 
 internal class SynnefoRunnerInfo(
-        synnefoOptions: SynnefoProperties,
+        val synnefoOptions: SynnefoProperties,
         private val cucumberFeature: CucumberFeature,
         private val lineId: Int?) {
     private val synnefoRuntimeOptions: SynnefoRuntimeOptionsCreator = SynnefoRuntimeOptionsCreator(synnefoOptions)


### PR DESCRIPTION
Add support for multiple annotations for each class.

The reason behind the decision is that currently we can't run different scenarios within the same project in parallel. One way to do it would be to parallelize on JUnit level, but at this moment JUnit5 (which is the one that supports parallel executions) is not supported. Therefore, we are going with multiple annotations on the same class. This is done by flattening the features from all the annotations into one "Job".

Cons:

Currently `threads` are set per annotation. So if an override is used it would override both settings. So, if you have 15 + 10 threads set (25 in total) and would override them to say 30, the result would be 30+30=60.