### PR TITLE
Append the whitelisted -D properties to the subrunners

### DIFF
--- a/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
@@ -409,18 +409,17 @@ internal class AmazonCodeBuildScheduler(private val classLoader: ClassLoader) {
     private fun getSystemProperties(): List<String> {
 
         val transferrableProperties = System.getProperty("SynnefoTransferrableProperties")
-
         if(transferrableProperties.isNullOrWhiteSpace())
             return arrayListOf()
 
-        val propetiesList = transferrableProperties.split(':')
+        val propertiesList = transferrableProperties.split(';')
 
         return System.getProperties()
             .map {
                 Pair(it.key.toString(), it.value.toString().trim())
             }
             .filter { pair ->
-                val isNotIgnored = propetiesList.any { pair.first.startsWith(it, ignoreCase = true) }
+                val isNotIgnored = propertiesList.any { pair.first.startsWith(it, ignoreCase = true) }
                 val isNotEmpty = !pair.second.isNullOrWhiteSpace()
                 isNotIgnored && isNotEmpty
             }

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
@@ -411,11 +411,12 @@ internal class AmazonCodeBuildScheduler(private val classLoader: ClassLoader) {
 
         return System.getProperties()
             .map {
-                Pair(it.key.toString(), it.value.toString())
+                Pair(it.key.toString(), it.value.toString().trim())
             }
             .filter { pair ->
-                val isIgnored = ignoredPrefixes.any { pair.first.startsWith(it, ignoreCase = true) }
-                isIgnored || pair.second.isNullOrWhiteSpace()
+                val isNotIgnored = !ignoredPrefixes.any { pair.first.startsWith(it, ignoreCase = true) }
+                val isNotEmpty = !pair.second.isNullOrWhiteSpace()
+                isNotIgnored && isNotEmpty
             }
             .map {
                     String.format("-D%s=%s", it.first, it.second)

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
@@ -391,9 +391,9 @@ internal class AmazonCodeBuildScheduler(private val classLoader: ClassLoader) {
     private fun generateBuildspecForFeature(jar: String, feature: String, runtimeOptions: List<String>): String {
         val sb = StringBuilder()
         sb.appendWithEscaping("java")
-        getSystemProperties().forEach { sb.appendWithEscaping(it) }
         sb.appendWithEscaping("-cp")
         sb.appendWithEscaping("./../$jar")
+        getSystemProperties().forEach { sb.appendWithEscaping(it) }
         sb.appendWithEscaping("cucumber.api.cli.Main")
         if(feature.startsWith("classpath")) {
             sb.appendWithEscaping(feature)
@@ -407,14 +407,20 @@ internal class AmazonCodeBuildScheduler(private val classLoader: ClassLoader) {
     }
 
     private fun getSystemProperties(): List<String> {
-        val ignoredPrefixes = arrayOf("cucumber", "Synnefo", "java", "sun")
+
+        val transferrableProperties = System.getProperty("SynnefoTransferrableProperties")
+
+        if(transferrableProperties.isNullOrWhiteSpace())
+            return arrayListOf()
+
+        val propetiesList = transferrableProperties.split(':')
 
         return System.getProperties()
             .map {
                 Pair(it.key.toString(), it.value.toString().trim())
             }
             .filter { pair ->
-                val isNotIgnored = !ignoredPrefixes.any { pair.first.startsWith(it, ignoreCase = true) }
+                val isNotIgnored = propetiesList.any { pair.first.startsWith(it, ignoreCase = true) }
                 val isNotEmpty = !pair.second.isNullOrWhiteSpace()
                 isNotIgnored && isNotEmpty
             }

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
@@ -401,7 +401,18 @@ internal class AmazonCodeBuildScheduler(private val classLoader: ClassLoader) {
             sb.appendWithEscaping("./../$feature")
         }
         runtimeOptions.forEach { sb.appendWithEscaping(it) }
+        getSystemProperties().forEach { sb.appendWithEscaping(it) }
 
         return String.format(this.buildSpecTemplate, sb.toString())
+    }
+
+    private fun getSystemProperties(): List<String> {
+        return System.getProperties()
+            .map {
+                String.format("-D%s=%s", it.key, it.value)
+            }.filter {
+                    (!it.startsWith("-Dcucumber")
+                    || !it.startsWith("-DSynnefo"))
+            }
     }
 }

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
@@ -391,6 +391,7 @@ internal class AmazonCodeBuildScheduler(private val classLoader: ClassLoader) {
     private fun generateBuildspecForFeature(jar: String, feature: String, runtimeOptions: List<String>): String {
         val sb = StringBuilder()
         sb.appendWithEscaping("java")
+        getSystemProperties().forEach { sb.appendWithEscaping(it) }
         sb.appendWithEscaping("-cp")
         sb.appendWithEscaping("./../$jar")
         sb.appendWithEscaping("cucumber.api.cli.Main")
@@ -401,7 +402,6 @@ internal class AmazonCodeBuildScheduler(private val classLoader: ClassLoader) {
             sb.appendWithEscaping("./../$feature")
         }
         runtimeOptions.forEach { sb.appendWithEscaping(it) }
-        getSystemProperties().forEach { sb.appendWithEscaping(it) }
 
         return String.format(this.buildSpecTemplate, sb.toString())
     }

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
@@ -407,12 +407,18 @@ internal class AmazonCodeBuildScheduler(private val classLoader: ClassLoader) {
     }
 
     private fun getSystemProperties(): List<String> {
+        val ignoredPrefixes = arrayOf("cucumber", "Synnefo", "java", "sun")
+
         return System.getProperties()
             .map {
-                String.format("-D%s=%s", it.key, it.value)
-            }.filter {
-                    (!it.startsWith("-Dcucumber")
-                    || !it.startsWith("-DSynnefo"))
+                Pair(it.key.toString(), it.value.toString())
+            }
+            .filter { pair ->
+                val isIgnored = ignoredPrefixes.any { pair.first.startsWith(it, ignoreCase = true) }
+                isIgnored || pair.second.isNullOrWhiteSpace()
+            }
+            .map {
+                    String.format("-D%s=%s", it.first, it.second)
             }
     }
 }

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/Extensions.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/Extensions.kt
@@ -15,9 +15,9 @@ internal fun <E> MutableList<E>.dequeueUpTo(limit: Int): MutableList<E> {
 
 internal fun StringBuilder.appendWithEscaping(s: String) {
     if (s.contains(' ') || s.contains(':'))
-        this.append("\"$s\" ").trim()
+        this.append("\"$s\" ")
     else
-        this.append("$s ").trim()
+        this.append("$s ")
 }
 
 internal fun String.isNullOrWhiteSpace(): Boolean {

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/Extensions.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/Extensions.kt
@@ -15,9 +15,9 @@ internal fun <E> MutableList<E>.dequeueUpTo(limit: Int): MutableList<E> {
 
 internal fun StringBuilder.appendWithEscaping(s: String) {
     if (s.contains(' ') || s.contains(':'))
-        this.append("\"$s\" ")
+        this.append("\"$s\" ").trim()
     else
-        this.append("$s ")
+        this.append("$s ").trim()
 }
 
 internal fun String.isNullOrWhiteSpace(): Boolean {


### PR DESCRIPTION
To pass the whitelisted properties to the subrunners `-DSynnefoTransferrableProperties` should be used.

E.g.:

`-DSynnefoTransferrableProperties=environment -Denvironment=Test`