### PR TITLE
Randomly shuffle the backlog before processing it

### DIFF
--- a/src/main/kotlin/albelli/junit/synnefo/api/Synnefo.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/api/Synnefo.kt
@@ -39,6 +39,9 @@ constructor(clazz: Class<*>) : ParentRunner<FeatureRunner>(clazz) {
                     runnerInfoList.add(SynnefoRunnerInfo(synnefoProperties, scenario, line))
                 }
             }
+
+            if (opt.shuffleBacklogBeforeExecution)
+                runnerInfoList.shuffle()
         }
     }
 

--- a/src/main/kotlin/albelli/junit/synnefo/api/SynnefoOptions.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/api/SynnefoOptions.kt
@@ -70,9 +70,12 @@ annotation class SynnefoOptions(
         /**
          * @return the name of the zipped artifacts file
          */
-        val outputFileName: String = "runResults.zip"
+        val outputFileName: String = "runResults.zip",
+        /**
+         * @return value indicating whether we should shuffle the backlog of tasks before scheduling them in CodeBuild
+         */
+        val shuffleBacklogBeforeExecution: Boolean
 )
-
 @Retention(RetentionPolicy.RUNTIME)
 @Target(AnnotationTarget.CLASS)
 annotation class SynnefoOptionsGroup(vararg val value: SynnefoOptions)

--- a/src/main/kotlin/albelli/junit/synnefo/api/SynnefoOptions.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/api/SynnefoOptions.kt
@@ -74,7 +74,7 @@ annotation class SynnefoOptions(
         /**
          * @return value indicating whether we should shuffle the backlog of tasks before scheduling them in CodeBuild
          */
-        val shuffleBacklogBeforeExecution: Boolean
+        val shuffleBacklogBeforeExecution: Boolean = false
 )
 @Retention(RetentionPolicy.RUNTIME)
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
@@ -131,7 +131,6 @@ internal class AmazonCodeBuildScheduler(private val classLoader: ClassLoader) {
     private suspend fun runAndWaitForJobs(job: Job, threads: Int, sourceLocations: Map<SynnefoProperties, String>) {
         val currentQueue = LinkedList<ScheduledJob>()
         val backlog = job.runnerInfos.toMutableList()
-        backlog.shuffle()
         val codeBuildRequestLimit = 100
         val s3Tasks = ArrayList<Deferred<Unit>>()
 

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
@@ -131,6 +131,7 @@ internal class AmazonCodeBuildScheduler(private val classLoader: ClassLoader) {
     private suspend fun runAndWaitForJobs(job: Job, threads: Int, sourceLocations: Map<SynnefoProperties, String>) {
         val currentQueue = LinkedList<ScheduledJob>()
         val backlog = job.runnerInfos.toMutableList()
+        backlog.shuffle()
         val codeBuildRequestLimit = 100
         val s3Tasks = ArrayList<Deferred<Unit>>()
 

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/SynnefoProperties.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/SynnefoProperties.kt
@@ -8,7 +8,7 @@ import software.amazon.awssdk.core.interceptor.Context
 import java.net.URI
 
 internal class SynnefoProperties(
-        val threads: Int ,
+        val threads: Int,
         val runLevel: SynnefoRunLevel,
         val reportTargetDir: String,
         val cucumberOptions: CucumberOptions,
@@ -21,9 +21,9 @@ internal class SynnefoProperties(
         val bucketOutputFolder: String,
         val outputFileName: String,
         val cucumberForcedTags: String,
+        val shuffleBacklogBeforeExecution: Boolean,
         val classPath: String,
-        val featurePaths: List<URI>,
-        val shuffleBacklogBeforeExecution: Boolean)
+        val featurePaths: List<URI>)
 {
     constructor(opt: SynnefoOptions): this(
             getAnyVar("threads", opt.threads),
@@ -39,10 +39,10 @@ internal class SynnefoProperties(
             getAnyVar("bucketOutputFolder", opt.bucketOutputFolder),
             getAnyVar("outputFileName", opt.outputFileName),
             opt.cucumberForcedTags,
+            getAnyVar("shuffleBacklogBeforeExecution", opt.shuffleBacklogBeforeExecution),
             "",
-            listOf(),
-            getAnyVar("shuffleBacklogBeforeExecution", opt.shuffleBacklogBeforeExecution)
-            )
+            listOf()
+    )
 
     constructor(opt: SynnefoProperties, classPath: String, featurePaths: List<URI>): this(
             opt.threads,
@@ -58,9 +58,9 @@ internal class SynnefoProperties(
             opt.bucketOutputFolder,
             opt.outputFileName,
             opt.cucumberForcedTags,
+            opt.shuffleBacklogBeforeExecution,
             classPath,
-            featurePaths,
-            opt.shuffleBacklogBeforeExecution
+            featurePaths
     )
 
     companion object {

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/SynnefoProperties.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/SynnefoProperties.kt
@@ -4,6 +4,7 @@ import albelli.junit.synnefo.api.SynnefoOptions
 import albelli.junit.synnefo.api.SynnefoRunLevel
 import albelli.junit.synnefo.runtime.exceptions.SynnefoException
 import cucumber.api.CucumberOptions
+import software.amazon.awssdk.core.interceptor.Context
 import java.net.URI
 
 internal class SynnefoProperties(
@@ -21,7 +22,8 @@ internal class SynnefoProperties(
         val outputFileName: String,
         val cucumberForcedTags: String,
         val classPath: String,
-        val featurePaths: List<URI>)
+        val featurePaths: List<URI>,
+        val shuffleBacklogBeforeExecution: Boolean)
 {
     constructor(opt: SynnefoOptions): this(
             getAnyVar("threads", opt.threads),
@@ -38,7 +40,8 @@ internal class SynnefoProperties(
             getAnyVar("outputFileName", opt.outputFileName),
             opt.cucumberForcedTags,
             "",
-            listOf()
+            listOf(),
+            getAnyVar("shuffleBacklogBeforeExecution", opt.shuffleBacklogBeforeExecution)
             )
 
     constructor(opt: SynnefoProperties, classPath: String, featurePaths: List<URI>): this(
@@ -56,7 +59,8 @@ internal class SynnefoProperties(
             opt.outputFileName,
             opt.cucumberForcedTags,
             classPath,
-            featurePaths
+            featurePaths,
+            opt.shuffleBacklogBeforeExecution
     )
 
     companion object {
@@ -89,6 +93,12 @@ internal class SynnefoProperties(
         {
             val anyVar = getAnyVar(varName)
             return anyVar ?: default
+        }
+
+        private fun getAnyVar(varName: String, default: Boolean) : Boolean
+        {
+            val anyVar = getAnyVar(varName)
+            return anyVar?.toBoolean() ?: default
         }
 
         @Throws(SynnefoException::class)


### PR DESCRIPTION
 * Add a new setting `shuffleBacklogBeforeExecution` that allows to shuffle the tests randomly before the execution
