### PR TITLE
Add retry functionality

### DIFF
--- a/src/main/kotlin/albelli/junit/synnefo/api/SynnefoOptions.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/api/SynnefoOptions.kt
@@ -74,7 +74,15 @@ annotation class SynnefoOptions(
         /**
          * @return value indicating whether we should shuffle the backlog of tasks before scheduling them in CodeBuild
          */
-        val shuffleBacklogBeforeExecution: Boolean = false
+        val shuffleBacklogBeforeExecution: Boolean = false,
+        /**
+         * @return value indicating how many times the whole run can retry
+         */
+        val maxRetries: Int = 0,
+        /**
+         * @return value indicating how many times can an individual test be retried
+         */
+        val retriesPerTest: Int = 3
 )
 @Retention(RetentionPolicy.RUNTIME)
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
@@ -176,11 +176,11 @@ internal class AmazonCodeBuildScheduler(private val classLoader: ClassLoader) {
                             println("build ${originalJob.info.cucumberFeatureLocation} failed")
                             val thisTestRetryConfiguration = retryConfiguration[originalJob.info.synnefoOptions] ?: error("Failed to get the retry configuration for ${originalJob.info.cucumberFeatureLocation}")
                             if (thisTestRetryConfiguration.maxRetries > 0) {
-                                println("It's still possible to retry with ${thisTestRetryConfiguration.maxRetries} total retires left")
+                                println("It's still possible to retry with ${thisTestRetryConfiguration.maxRetries} total retries left")
                                 val previousRetries = triesPerTest.getOrDefault(originalJob.info.cucumberFeatureLocation, 0);
                                 triesPerTest[originalJob.info.cucumberFeatureLocation] = previousRetries + 1;
                                 val currentRetries = triesPerTest[originalJob.info.cucumberFeatureLocation]!!
-                                if (currentRetries < thisTestRetryConfiguration.retriesPerTest) {
+                                if (currentRetries <= thisTestRetryConfiguration.retriesPerTest) {
                                     println("Adding the test back to the backlog.")
                                     thisTestRetryConfiguration.maxRetries--
                                     backlog.add(originalJob.info)

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
@@ -184,6 +184,7 @@ internal class AmazonCodeBuildScheduler(private val classLoader: ClassLoader) {
                                     println("Adding the test back to the backlog.")
                                     thisTestRetryConfiguration.maxRetries--
                                     backlog.add(originalJob.info)
+                                    return@run 
                                 } else  {
                                     println("But this test had exhausted the maximum retries per test")
                                 }

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
@@ -435,6 +435,7 @@ internal class AmazonCodeBuildScheduler(private val classLoader: ClassLoader) {
         sb.appendWithEscaping("java")
         sb.appendWithEscaping("-cp")
         sb.appendWithEscaping("./../$jar")
+        sb.appendWithEscaping(String.format("-D%s=%s", "java.random.seed", randomSeed))
         getSystemProperties().forEach { sb.appendWithEscaping(it) }
         sb.appendWithEscaping("cucumber.api.cli.Main")
         if (feature.startsWith("classpath")) {
@@ -444,7 +445,6 @@ internal class AmazonCodeBuildScheduler(private val classLoader: ClassLoader) {
         }
         runtimeOptions.forEach { sb.appendWithEscaping(it) }
 
-        sb.appendWithEscaping(String.format("-D%s=%s", "java.random.seed", randomSeed))
 
         val image = if (useStandardImage) {
             this.buildSpecTemplateStandard2_0

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/SynnefoProperties.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/SynnefoProperties.kt
@@ -4,7 +4,6 @@ import albelli.junit.synnefo.api.SynnefoOptions
 import albelli.junit.synnefo.api.SynnefoRunLevel
 import albelli.junit.synnefo.runtime.exceptions.SynnefoException
 import cucumber.api.CucumberOptions
-import software.amazon.awssdk.core.interceptor.Context
 import java.net.URI
 
 internal class SynnefoProperties(

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/SynnefoProperties.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/SynnefoProperties.kt
@@ -22,6 +22,8 @@ internal class SynnefoProperties(
         val outputFileName: String,
         val cucumberForcedTags: String,
         val shuffleBacklogBeforeExecution: Boolean,
+        val maxRetries: Int,
+        val retriesPerTest: Int,
         val classPath: String,
         val featurePaths: List<URI>)
 {
@@ -40,6 +42,8 @@ internal class SynnefoProperties(
             getAnyVar("outputFileName", opt.outputFileName),
             opt.cucumberForcedTags,
             getAnyVar("shuffleBacklogBeforeExecution", opt.shuffleBacklogBeforeExecution),
+            getAnyVar("maxRetries", opt.maxRetries),
+            getAnyVar("retriesPerTest", opt.retriesPerTest),
             "",
             listOf()
     )
@@ -59,6 +63,8 @@ internal class SynnefoProperties(
             opt.outputFileName,
             opt.cucumberForcedTags,
             opt.shuffleBacklogBeforeExecution,
+            opt.maxRetries,
+            opt.retriesPerTest,
             classPath,
             featurePaths
     )

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/exceptions/SynnefoTestStoppedException.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/exceptions/SynnefoTestStoppedException.kt
@@ -1,7 +1,6 @@
 package albelli.junit.synnefo.runtime.exceptions
 
-class SynnefoTestFailureException(message: String) : RuntimeException(message) {
-
+class SynnefoTestStoppedException(message: String) : RuntimeException(message) {
     @Synchronized
     override fun fillInStackTrace(): Throwable {
         return this

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/exceptions/SynnefoTestTimedOutException.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/exceptions/SynnefoTestTimedOutException.kt
@@ -1,10 +1,8 @@
 package albelli.junit.synnefo.runtime.exceptions
 
-class SynnefoTestFailureException(message: String) : RuntimeException(message) {
-
+class SynnefoTestTimedOutException(message: String) : RuntimeException(message) {
     @Synchronized
     override fun fillInStackTrace(): Throwable {
         return this
     }
 }
-


### PR DESCRIPTION
Add retry functionality to the AmazonCodeBuildScheduler.

Now we have two more parameters: `maxRetries` and `retriesPerTest`.
`retriesPerTest` has a default value of `3`, while `maxRetries` has a defaul value of `0`.
What this means is that nothing will be retried by default and the overall retry value should be explicitly set.

Both parameters can be overridden using the same techniques as all the other parameters: via a `-D` system variable or via environment variables.

All the retries pass the same random seed as a `-Djava.random.seed` parameter so the test can pick it up and restart using the exact same values.