### PR TITLE
Add codebuild runtime versions as a parameter

### DIFF
--- a/src/main/kotlin/albelli/junit/synnefo/api/SynnefoOptions.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/api/SynnefoOptions.kt
@@ -87,7 +87,7 @@ annotation class SynnefoOptions(
          * @return a set of CodeBuild runtimes to initialize.
          * See the docu for details: https://docs.aws.amazon.com/codebuild/latest/userguide/sample-runtime-versions.html
          */
-        val codeBuildRunTimeVersions: Array<String>
+        val codeBuildRunTimeVersions: Array<String> = []
         )
 @Retention(RetentionPolicy.RUNTIME)
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/albelli/junit/synnefo/api/SynnefoOptions.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/api/SynnefoOptions.kt
@@ -82,8 +82,13 @@ annotation class SynnefoOptions(
         /**
          * @return value indicating how many times can an individual test be retried
          */
-        val retriesPerTest: Int = 3
-)
+        val retriesPerTest: Int = 3,
+        /**
+         * @return a set of CodeBuild runtimes to initialize.
+         * See the docu for details: https://docs.aws.amazon.com/codebuild/latest/userguide/sample-runtime-versions.html
+         */
+        val codeBuildRunTimeVersions: Array<String>
+        )
 @Retention(RetentionPolicy.RUNTIME)
 @Target(AnnotationTarget.CLASS)
 annotation class SynnefoOptionsGroup(vararg val value: SynnefoOptions)

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/SynnefoProperties.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/SynnefoProperties.kt
@@ -23,6 +23,7 @@ internal class SynnefoProperties(
         val shuffleBacklogBeforeExecution: Boolean,
         val maxRetries: Int,
         val retriesPerTest: Int,
+        val codeBuildRunTimeVersions: Array<String>,
         val classPath: String,
         val featurePaths: List<URI>)
 {
@@ -43,6 +44,7 @@ internal class SynnefoProperties(
             getAnyVar("shuffleBacklogBeforeExecution", opt.shuffleBacklogBeforeExecution),
             getAnyVar("maxRetries", opt.maxRetries),
             getAnyVar("retriesPerTest", opt.retriesPerTest),
+            opt.codeBuildRunTimeVersions,
             "",
             listOf()
     )
@@ -64,6 +66,7 @@ internal class SynnefoProperties(
             opt.shuffleBacklogBeforeExecution,
             opt.maxRetries,
             opt.retriesPerTest,
+            opt.codeBuildRunTimeVersions,
             classPath,
             featurePaths
     )


### PR DESCRIPTION
Example usage:

```
@SynnefoOptions(
        threads = 1,
// ....
        codeBuildRunTimeVersions = {"java: openjdk8"},
        cucumberOptions = @CucumberOptions(
// ...
        ))
```