### PR TITLE
Roll back the AWS SDK dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ bintray {
 
 dependencyManagement {
     imports {
-        mavenBom "software.amazon.awssdk:bom:2.10.49"
+        mavenBom "software.amazon.awssdk:bom:2.5.23"
     }
 }
 
@@ -67,9 +67,9 @@ dependencies {
     compile "io.cucumber:cucumber-java:$cucumber_version"
     compile "io.cucumber:cucumber-java8:$cucumber_version"
     compile "io.cucumber:cucumber-junit:$cucumber_version"
-    compile "software.amazon.awssdk:s3:2.10.49"
-    compile "software.amazon.awssdk:codebuild:2.10.49"
-    compile "software.amazon.awssdk:sdk-core:2.10.49"
+    compile "software.amazon.awssdk:s3:2.5.23"
+    compile 'software.amazon.awssdk:codebuild:2.5.23'
+    compile "software.amazon.awssdk:sdk-core:2.5.23"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.3.3"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.3"

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     compile "io.cucumber:cucumber-java8:$cucumber_version"
     compile "io.cucumber:cucumber-junit:$cucumber_version"
     compile "software.amazon.awssdk:s3:2.5.23"
-    compile 'software.amazon.awssdk:codebuild:2.5.23'
+    compile "software.amazon.awssdk:codebuild:2.5.23"
     compile "software.amazon.awssdk:sdk-core:2.5.23"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.3.3"


### PR DESCRIPTION
This update caused a lot of unexpected failures of the CodeBuild API calls
This smells like a race condition in the AWS SDK and since we had issues with it before, it probably is best to roll it back for the time being