### PR TITLE
Update AWS Clients to Make Them More Resilient

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     compile "io.cucumber:cucumber-java8:$cucumber_version"
     compile "io.cucumber:cucumber-junit:$cucumber_version"
     compile "software.amazon.awssdk:s3:2.13.38"
+    compile "software.amazon.awssdk:url-connection-client:2.13.38"
     compile "software.amazon.awssdk:codebuild:2.13.38"
     compile "software.amazon.awssdk:sdk-core:2.13.38"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
@@ -262,6 +262,7 @@ internal class AmazonCodeBuildScheduler(private val classLoader: ClassLoader) {
                 break
             }
             catch(e: Exception){
+                println("S3 call to get build $buildId artifacts failed with ${e.printStackTrace()}. Retrying...(retry #$i)")
                 delay(2000)
                 if (i == 5) throw e else continue
             }

--- a/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
+++ b/src/main/kotlin/albelli/junit/synnefo/runtime/AmazonCodeBuildScheduler.kt
@@ -13,6 +13,7 @@ import software.amazon.awssdk.core.retry.RetryUtils
 import software.amazon.awssdk.core.retry.backoff.BackoffStrategy
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.core.sync.ResponseTransformer
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient
 import software.amazon.awssdk.services.codebuild.CodeBuildClient
 import software.amazon.awssdk.services.codebuild.model.*
 import software.amazon.awssdk.services.codebuild.model.StatusType.*
@@ -32,9 +33,17 @@ internal class AmazonCodeBuildScheduler(private val classLoader: ClassLoader) {
     // At this point the only way to use them is to use the environment variables
     private val s3: S3Client = S3Client
             .builder()
+            .overrideConfiguration {
+                it.retryPolicy(retryPolicy())
+            }
+            .httpClientBuilder { UrlConnectionHttpClient.builder()
+                    .build() }
             .build()
     private val codeBuild: CodeBuildClient = CodeBuildClient
             .builder()
+            .httpClientBuilder { UrlConnectionHttpClient.builder()
+                    .build()
+            }
             .overrideConfiguration {
                 it.retryPolicy(retryPolicy())
             }


### PR DESCRIPTION
- Add a handwritten retry policy for the S3::GetObject due to the AWS implementation
- Use UrlConnection instead of Apache